### PR TITLE
[Fix]ディスカッションのリンクを変愚蛮奴のものに修正

### DIFF
--- a/development.html
+++ b/development.html
@@ -173,7 +173,7 @@
             </div>
             <div class="paragraph">
               <p>以上を踏まえて、持ち込みは現在<a
-                  href="https://github.com/sikabane-works/bakabakaband/discussions">Discussions</a>で募集しています。</p>
+                  href=https://github.com/hengband/hengband/discussions">Discussions</a>で募集しています。</p>
             </div>
           </div>
           <div class="sect2">


### PR DESCRIPTION
[development.html](https://hengband.github.io/development.html#_%E3%82%B2%E3%83%BC%E3%83%A0%E4%B8%AD%E3%81%AB%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%E3%82%84%E3%82%A2%E3%82%A4%E3%83%86%E3%83%A0%E3%81%AA%E3%81%A9%E3%81%AE%E3%82%A2%E3%82%A4%E3%83%87%E3%82%A2%E6%96%B0%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0%E3%82%92%E6%8C%81%E3%81%A1%E8%BE%BC%E3%81%BF%E3%81%9F%E3%81%84)のリンクを馬鹿馬鹿蛮奴のdiscussionsから変愚蛮奴のdiscussionsに変更。
もし理由があって馬鹿馬鹿蛮奴のdiscussionsに設定しているのであればご迷惑をおかけしました。
新リンク：https://github.com/hengband/hengband/discussions