### PR TITLE
[Fix]リンクを再度修正

### DIFF
--- a/development.html
+++ b/development.html
@@ -173,7 +173,7 @@
             </div>
             <div class="paragraph">
               <p>以上を踏まえて、持ち込みは現在<a
-                  href=https://github.com/hengband/hengband/discussions">Discussions</a>で募集しています。</p>
+                  href="https://github.com/hengband/hengband/discussions">Discussions</a>で募集しています。</p>
             </div>
           </div>
           <div class="sect2">


### PR DESCRIPTION
ダブルクォーテーションマークが抜けてしまっていたので修正です。
リンク差し替えるだけなので大丈夫だろうと思っていたら、見事にやらかしました…。
今度は動作テストも行いました。お手数をおかけしますがご確認お願いいたします。